### PR TITLE
Added a small fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Compiled Python files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyCharm
+/.idea

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,4 @@ setup(
     author='tumbler',
     author_email='zimbler@gmail.com',
     description='Vertica backend for Django',
-    install_requires=[
-        'vertica-python>=0.2.4,<0.3'
-    ]
 )


### PR DESCRIPTION
I had a bit of a problem installing the package, found out it was because the versions or _vertica-python_ contradicted each other in _setup.py_ and _requires.txt_, Plus, the version range specified in _setup.py_ does not even exist...
And also added a basic gitignore file to the project.